### PR TITLE
Added swiper to mini me page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@ngx-pwa/local-storage": "^15.0.0",
         "ionicons": "^6.0.3",
         "rxjs": "~7.5.0",
+        "swiper": "^8.4.7",
         "tslib": "^2.3.0",
         "zone.js": "~0.11.4"
       },
@@ -6121,6 +6122,14 @@
       },
       "funding": {
         "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/dom7": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/dom7/-/dom7-4.0.6.tgz",
+      "integrity": "sha512-emjdpPLhpNubapLFdjNL9tP06Sr+GZkrIHEXLWvOGsytACUrkbeIdjO5g77m00BrHTznnlcNqgmn7pCN192TBA==",
+      "dependencies": {
+        "ssr-window": "^4.0.0"
       }
     },
     "node_modules/domelementtype": {
@@ -13108,6 +13117,11 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
     },
+    "node_modules/ssr-window": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/ssr-window/-/ssr-window-4.0.2.tgz",
+      "integrity": "sha512-ISv/Ch+ig7SOtw7G2+qkwfVASzazUnvlDTwypdLoPoySv+6MqlOV10VwPSE6EWkGjhW50lUmghPmpYZXMu/+AQ=="
+    },
     "node_modules/ssri": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/ssri/-/ssri-10.0.1.tgz",
@@ -13302,6 +13316,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swiper": {
+      "version": "8.4.7",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-8.4.7.tgz",
+      "integrity": "sha512-VwO/KU3i9IV2Sf+W2NqyzwWob4yX9Qdedq6vBtS0rFqJ6Fa5iLUJwxQkuD4I38w0WDJwmFl8ojkdcRFPHWD+2g==",
+      "funding": [
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/swiperjs"
+        },
+        {
+          "type": "open_collective",
+          "url": "http://opencollective.com/swiper"
+        }
+      ],
+      "hasInstallScript": true,
+      "dependencies": {
+        "dom7": "^4.0.4",
+        "ssr-window": "^4.0.2"
+      },
+      "engines": {
+        "node": ">= 4.7.0"
       }
     },
     "node_modules/symbol-observable": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@ngx-pwa/local-storage": "^15.0.0",
     "ionicons": "^6.0.3",
     "rxjs": "~7.5.0",
+    "swiper": "^8.4.7",
     "tslib": "^2.3.0",
     "zone.js": "~0.11.4"
   },

--- a/src/app/mini-me/mini-me-builder/mini-me-builder.module.ts
+++ b/src/app/mini-me/mini-me-builder/mini-me-builder.module.ts
@@ -6,15 +6,12 @@ import { IonicModule } from '@ionic/angular';
 
 import { MiniMeBuilderPageRoutingModule } from './mini-me-builder-routing.module';
 
-import { MiniMeBuilderPage } from './mini-me-builder.page';
-
 @NgModule({
   imports: [
     CommonModule,
     FormsModule,
     IonicModule,
     MiniMeBuilderPageRoutingModule
-  ],
-  declarations: [MiniMeBuilderPage]
+  ]
 })
 export class MiniMeBuilderPageModule {}

--- a/src/app/mini-me/mini-me-confirm/mini-me-confirm.module.ts
+++ b/src/app/mini-me/mini-me-confirm/mini-me-confirm.module.ts
@@ -6,15 +6,12 @@ import { IonicModule } from '@ionic/angular';
 
 import { MiniMeConfirmPageRoutingModule } from './mini-me-confirm-routing.module';
 
-import { MiniMeConfirmPage } from './mini-me-confirm.page';
-
 @NgModule({
   imports: [
     CommonModule,
     FormsModule,
     IonicModule,
     MiniMeConfirmPageRoutingModule
-  ],
-  declarations: [MiniMeConfirmPage]
+  ]
 })
 export class MiniMeConfirmPageModule {}

--- a/src/app/mini-me/mini-me-setup/mini-me-setup.module.ts
+++ b/src/app/mini-me/mini-me-setup/mini-me-setup.module.ts
@@ -6,15 +6,12 @@ import { IonicModule } from '@ionic/angular';
 
 import { MiniMeSetupPageRoutingModule } from './mini-me-setup-routing.module';
 
-import { MiniMeSetupPage } from './mini-me-setup.page';
-
 @NgModule({
   imports: [
     CommonModule,
     FormsModule,
     IonicModule,
     MiniMeSetupPageRoutingModule
-  ],
-  declarations: [MiniMeSetupPage]
+  ]
 })
 export class MiniMeSetupPageModule {}

--- a/src/app/mini-me/mini-me.module.ts
+++ b/src/app/mini-me/mini-me.module.ts
@@ -7,14 +7,24 @@ import { IonicModule } from '@ionic/angular';
 import { MiniMePageRoutingModule } from './mini-me-routing.module';
 
 import { MiniMePage } from './mini-me.page';
+import { MiniMeSetupPage } from '../mini-me/mini-me-setup/mini-me-setup.page';
+import { MiniMeBuilderPage } from '../mini-me/mini-me-builder/mini-me-builder.page';
+import { MiniMeConfirmPage } from '../mini-me/mini-me-confirm/mini-me-confirm.page';
+import { SwiperModule } from 'swiper/angular';
 
 @NgModule({
   imports: [
     CommonModule,
     FormsModule,
     IonicModule,
-    MiniMePageRoutingModule
+    MiniMePageRoutingModule,
+    SwiperModule,
   ],
-  declarations: [MiniMePage]
+  declarations: [
+    MiniMePage,
+    MiniMeSetupPage,
+    MiniMeBuilderPage,
+    MiniMeConfirmPage
+  ]
 })
-export class MiniMePageModule {}
+export class MiniMePageModule { }

--- a/src/app/mini-me/mini-me.page.html
+++ b/src/app/mini-me/mini-me.page.html
@@ -1,9 +1,21 @@
-<ion-header>
-  <ion-toolbar>
-    <ion-title>mini-me</ion-title>
-  </ion-toolbar>
+<ion-header [translucent]="true">
 </ion-header>
 
 <ion-content>
+  <swiper [config]="config">
+
+    <ng-template swiperSlide>
+      <app-mini-me-setup></app-mini-me-setup>
+    </ng-template>
+
+    <ng-template swiperSlide>
+      <app-mini-me-builder></app-mini-me-builder>
+    </ng-template>
+
+    <ng-template swiperSlide>
+      <app-mini-me-confirm></app-mini-me-confirm>
+    </ng-template>
+
+  </swiper>
 
 </ion-content>

--- a/src/app/mini-me/mini-me.page.scss
+++ b/src/app/mini-me/mini-me.page.scss
@@ -1,0 +1,3 @@
+swiper {
+    height: 100%;
+}

--- a/src/app/mini-me/mini-me.page.ts
+++ b/src/app/mini-me/mini-me.page.ts
@@ -1,4 +1,7 @@
 import { Component, OnInit } from '@angular/core';
+import Swiper, { SwiperOptions, Pagination } from 'swiper';
+
+Swiper.use([Pagination]);
 
 @Component({
   selector: 'app-mini-me',
@@ -6,6 +9,10 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./mini-me.page.scss'],
 })
 export class MiniMePage implements OnInit {
+  config: SwiperOptions = {
+    pagination: true,
+    allowTouchMove: true
+  };
 
   constructor() { }
 

--- a/src/global.scss
+++ b/src/global.scss
@@ -24,3 +24,7 @@
 @import "~@ionic/angular/css/text-alignment.css";
 @import "~@ionic/angular/css/text-transformation.css";
 @import "~@ionic/angular/css/flex-utils.css";
+
+/* Swiper CSS */
+@import 'swiper/scss';
+@import 'swiper/scss/pagination';


### PR DESCRIPTION
Mini Me main page should now show 3 slides: Setup, Builder, and Confirm. None of the HTML pages others are working on were touched for easy merge. Temporarily activated swiping so there's a way to view all slides without buttons.

Update npm packages and build to test mini me page has all 3 slides.
http://localhost:8101/#/mini-me