### PR TITLE
Add GA4 test event and use history route

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -13,7 +13,7 @@ const routes: Routes = [
 ];
 @NgModule({
   imports: [
-    RouterModule.forRoot(routes, { preloadingStrategy: PreloadAllModules, useHash: true })
+    RouterModule.forRoot(routes, { preloadingStrategy: PreloadAllModules, useHash: false })
   ],
   exports: [RouterModule]
 })

--- a/src/app/routine-home/routine-home.page.html
+++ b/src/app/routine-home/routine-home.page.html
@@ -15,10 +15,10 @@
   </ion-text>
 
   <ion-segment [scrollable]="true" value="night">
-    <ion-segment-button value="day">
+    <ion-segment-button value="day" (click)="onClickDay()">
       <ion-icon name="sunny-outline"></ion-icon>
     </ion-segment-button>
-    <ion-segment-button value="night">
+    <ion-segment-button value="night" (click)="onClickNight()">
       <ion-icon name="moon-outline"></ion-icon>
     </ion-segment-button>
   </ion-segment>

--- a/src/app/routine-home/routine-home.page.ts
+++ b/src/app/routine-home/routine-home.page.ts
@@ -1,5 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 
+declare const gtag: Function;
+
 @Component({
   selector: 'app-routine-home',
   templateUrl: './routine-home.page.html',
@@ -12,4 +14,11 @@ export class RoutineHomePage implements OnInit {
   ngOnInit() {
   }
 
+  onClickDay() {
+    gtag('event', 'select_content', {item_id: 'routine_clicked_day'})
+  }
+
+  onClickNight() {
+    gtag('event', 'select_content', {item_id: 'routine_clicked_night'})
+  }
 }


### PR DESCRIPTION
Changed the routing from hash routing to history routing, so the URL doesn't have the # anymore. This plays nicer with GA4's automatic page_view event.

Also created a test analytics event on the Routine page based on whether someone clicked night or day. You should be able to see it in Google Analytics under Engagement -> Events -> select_content.

It could probably be refactored to be easier to use, but this should prove the concept :)

closes #9 